### PR TITLE
Run tests on Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,57 @@
-venv/
-*.pyc
-*.swp
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
 dist/
-*.egg-info
-MANIFEST
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,8 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Project Corpora downloads
+corpora-download/
+pycorpora/data/
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ python:
 sudo: false
 
 install:
+  - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then travis_retry pip install unittest2; fi
   - travis_retry python setup.py install
   - travis_retry pip install coveralls
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+language: python
+
+python:
+  - "pypy"
+  - "pypy3"
+  - 2.7
+  - 3.4
+  - 2.6
+  - 3.2
+  - 3.3
+
+sudo: false
+
+install:
+  - "travis_retry python setup.py install"
+
+script:
+  - coverage run --include=pycorpora/* tests/test_pycorpora.py
+
+after_success:
+    # Report coverage and send to coveralls.io
+  - coverage report
+  - travis_retry pip install coveralls
+  - coveralls
+
+    # Static analysis
+  - travis_retry pip install pep8 pyflakes
+  - pep8 --statistics --count PIL/*.py
+  - pep8  --statistics --count Tests/*.py
+  - pyflakes *.py       | tee >(wc -l)
+  - pyflakes PIL/*.py   | tee >(wc -l)
+  - pyflakes Tests/*.py | tee >(wc -l)
+
+
+matrix:
+  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ python:
 sudo: false
 
 install:
-  - "travis_retry python setup.py install"
+  - travis_retry python setup.py install
+  - travis_retry pip install coveralls
 
 script:
   - coverage run --include=pycorpora/* tests/test_pycorpora.py
@@ -20,7 +21,6 @@ script:
 after_success:
     # Report coverage and send to coveralls.io
   - coverage report
-  - travis_retry pip install coveralls
   - coveralls
 
     # Static analysis

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,12 @@ after_success:
 
     # Static analysis
   - travis_retry pip install pep8 pyflakes
-  - pep8 --statistics --count PIL/*.py
-  - pep8  --statistics --count Tests/*.py
-  - pyflakes *.py       | tee >(wc -l)
-  - pyflakes PIL/*.py   | tee >(wc -l)
-  - pyflakes Tests/*.py | tee >(wc -l)
+  - pep8 --statistics --count *.py
+  - pep8 --statistics --count pycorpora/*.py
+  - pep8 --statistics --count tests/*.py
+  - pyflakes *.py           | tee >(wc -l)
+  - pyflakes pycorpora/*.py | tee >(wc -l)
+  - pyflakes tests/*.py     | tee >(wc -l)
 
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 
 python:
-  - "pypy"
-  - "pypy3"
+  - pypy
+  - pypy3
   - 2.7
   - 3.4
   - 2.6
@@ -35,3 +35,9 @@ after_success:
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - python: pypy3
+    - python: 3.2
+    - python: 3.3
+    - python: 3.4
+

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,15 @@ try:
 except ImportError:
 	from distutils.core import setup
 	from distutils.command.install import install
+try:
+    # For Python 3.0 and later
+    from urllib.request import urlopen
+except ImportError:
+    # Fall back to Python 2's urllib2
+    from urllib2 import urlopen
 from distutils.dir_util import mkpath, copy_tree
-import io, urllib2, zipfile, glob
+import io, zipfile, glob
+
 
 class DownloadAndInstall(install):
 	user_options = install.user_options + [
@@ -22,7 +29,7 @@ class DownloadAndInstall(install):
 				"https://github.com/dariusk/corpora/archive/master.zip"
 		print("Installing corpora data from " + self.corpora_zip_url)
 		mkpath("./corpora-download")
-		resp = urllib2.urlopen(self.corpora_zip_url).read()
+		resp = urlopen(self.corpora_zip_url).read()
 		remote = io.BytesIO(resp)
 		zf = zipfile.ZipFile(remote, "r")
 		zf.extractall("corpora-download")

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 try:
 	from setuptools import setup
 	from setuptools.command.install import install
@@ -19,7 +20,7 @@ class DownloadAndInstall(install):
 		if self.corpora_zip_url is None:
 			self.corpora_zip_url = \
 				"https://github.com/dariusk/corpora/archive/master.zip"
-		print "Installing corpora data from " + self.corpora_zip_url
+		print("Installing corpora data from " + self.corpora_zip_url)
 		mkpath("./corpora-download")
 		resp = urllib2.urlopen(self.corpora_zip_url).read()
 		remote = io.BytesIO(resp)

--- a/tests/test_pycorpora.py
+++ b/tests/test_pycorpora.py
@@ -1,4 +1,7 @@
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 class TestPyCorpora(unittest.TestCase):
 
@@ -83,7 +86,7 @@ class TestPyCorpora(unittest.TestCase):
 		subdata = pycorpora.pycorpora_test.subdir.get_file('another_test')
 		self.assertEqual(type(data), dict)
 		self.assertEqual(data['tests'], ["one", "two", "three"])
-	
+
 	def test_cache(self):
 		import pycorpora
 		self.assertNotIn('data/pycorpora_test/test.json', pycorpora.cache)


### PR DESCRIPTION
Please enable Travis CI for aparrish/pycorpora at https://travis-ci.org/profile/
- Run on all supported Python versions
- Python 2 passes, Python 3 needs a bit more work. Currently Python 3 is marked as `allowed_failures` so won't fail the build. Shouldn't be too hard to get it working for Python 3, and then the `allowed_failures` can be removed.
- Update .gitigore
