### PR TITLE
Don't allow Python 3 to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: python
 
 python:
-  - pypy
   - pypy3
-  - 2.7
+  - pypy
   - 3.4
-  - 2.6
-  - 3.2
   - 3.3
+  - 3.2
+  - 2.7
+  - 2.6
 
 sudo: false
 
@@ -36,9 +36,3 @@ after_success:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - python: pypy3
-    - python: 3.2
-    - python: 3.3
-    - python: 3.4
-


### PR DESCRIPTION
Now pycorpora's Python 3 compatible (#5), let's keep it that way: don't allow Python 3 failures on Travis CI.
