### PR TITLE
Allow hyphenated category names to be accessed as attributes

### DIFF
--- a/pycorpora/__init__.py
+++ b/pycorpora/__init__.py
@@ -64,4 +64,4 @@ class CorpusLoader(object):
 
 module = sys.modules[__name__]
 for directory in resource_listdir(__name__, "data"):
-    setattr(module, directory, CorpusLoader(directory))
+    setattr(module, directory.replace("-","_"), CorpusLoader(directory))

--- a/pycorpora/data/hyphenated-dirname/test.json
+++ b/pycorpora/data/hyphenated-dirname/test.json
@@ -1,0 +1,1 @@
+{"description": "test", "tests": ["one", "two", "three"]}

--- a/tests/test_pycorpora.py
+++ b/tests/test_pycorpora.py
@@ -9,11 +9,16 @@ class TestPyCorpora(unittest.TestCase):
     def test_import(self):
         import pycorpora
         self.assertTrue(hasattr(pycorpora, 'pycorpora_test'))
+        self.assertTrue(hasattr(pycorpora, 'hyphenated_dirname'))
 
     def test_load_corpus(self):
         import pycorpora
         self.assertEqual(type(pycorpora.pycorpora_test.test), dict)
         self.assertEqual(pycorpora.pycorpora_test.test['tests'],
+                         ["one", "two", "three"])
+
+        self.assertEqual(type(pycorpora.hyphenated_dirname.test), dict)
+        self.assertEqual(pycorpora.hyphenated_dirname.test['tests'],
                          ["one", "two", "three"])
 
     def test_subdir(self):


### PR DESCRIPTION
Thanks for this library, it's tons of fun.

I noticed that categories with hyphenated names, like [film-tv](https://github.com/dariusk/corpora/tree/master/data/film-tv) cannot be accessed as attributes since hyphens are not valid in attribute names. :(

This pr alters the attribute creation process, replacing hyphens with underscores for valid attribute names. It doesn't "underscorify" category names listed by `get_category()`, however, as that works as expected.

Wasn't sure if this was worth a readme update.
