### PR TITLE
Add CORPORA_ZIP_URL environment variable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,9 +48,15 @@ methods above::
 
     pip install pycorpora --install-option="--corpora-zip-url=https://github.com/dariusk/corpora/archive/master.zip"
 
+Alternatively, the ``CORPORA_ZIP_URL`` environment variable can be used for the
+same purpose (if both are set, the command line option will take precedence)::
+
+    env CORPORA_ZIP_URL=https://github.com/dariusk/corpora/archive/master.zip pip install pycorpora
+
 (The intention of ``--corpora-zip-url`` is to let you install Corpora Project
 data from a particular branch, commit or fork, so that changes to the bleeding
-edge of the project don't break your code.)
+edge of the project don't break your code. Also, a ``file://`` URL can be used
+for a local/vendored zip file.)
 
 Update
 ------

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ from distutils.dir_util import mkpath, copy_tree
 import glob
 import io
 import zipfile
+import os
 
 
 class DownloadAndInstall(install):
@@ -30,8 +31,10 @@ class DownloadAndInstall(install):
 
     def run(self):
         if self.corpora_zip_url is None:
-            self.corpora_zip_url = \
-                "https://github.com/dariusk/corpora/archive/master.zip"
+            self.corpora_zip_url = os.environ.get(
+                "CORPORA_ZIP_URL",
+                "https://github.com/dariusk/corpora/archive/master.zip",
+            )
         print("Installing corpora data from " + self.corpora_zip_url)
         mkpath("./corpora-download")
         resp = urlopen(self.corpora_zip_url).read()


### PR DESCRIPTION
- Use the `$CORPORA_ZIP_URL` environment variable if it's set and `--corpora-zip-url` isn't given.

- This will enable builds on [NixOS] using [pypi2nix]; see nix-community/pypi2nix#420

- Note that `file://` URLs can be used for a local copy of the Corpora zip in the readme.


  [NixOS]: https://nixos.org/
  [pypi2nix]: https://github.com/nix-community/pypi2nix